### PR TITLE
Fix: Resolve vercel.json conflict between routes and headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,10 +6,10 @@
       "use": "@vercel/static"
     }
   ],
-  "routes": [
+  "rewrites": [
     {
-      "src": "/(.*)",
-      "dest": "/index.html"
+      "source": "/(.*)",
+      "destination": "/index.html"
     }
   ],
   "headers": [


### PR DESCRIPTION
Replaced the `routes` configuration with an equivalent `rewrites` rule to maintain SPA fallback behavior while allowing the use of the `headers` property. This resolves a Vercel deployment error where `routes` cannot be used in conjunction with `headers`.