### PR TITLE
Improve timeline AI layout, local model, encrypted API key & celebration burst

### DIFF
--- a/src/lib/ai/useAiKey.ts
+++ b/src/lib/ai/useAiKey.ts
@@ -4,6 +4,60 @@ import { useEffect, useState } from "react";
 import { doc, getDoc, setDoc, collection } from "firebase/firestore";
 import { db } from "@/lib/firebase/client";
 
+const KEY_STORAGE_ID = "timeline_ai_key_secret_v1";
+
+function bytesToBase64(bytes: Uint8Array) {
+  let binary = "";
+  bytes.forEach((b) => {
+    binary += String.fromCharCode(b);
+  });
+  return btoa(binary);
+}
+
+function base64ToBytes(base64: string) {
+  const binary = atob(base64);
+  return Uint8Array.from(binary, (c) => c.charCodeAt(0));
+}
+
+async function getOrCreateCryptoKey(): Promise<CryptoKey | null> {
+  if (typeof window === "undefined" || !window.crypto?.subtle) return null;
+  let stored = window.localStorage.getItem(KEY_STORAGE_ID);
+  if (!stored) {
+    const raw = window.crypto.getRandomValues(new Uint8Array(32));
+    stored = bytesToBase64(raw);
+    window.localStorage.setItem(KEY_STORAGE_ID, stored);
+  }
+  const rawBytes = base64ToBytes(stored);
+  return window.crypto.subtle.importKey("raw", rawBytes, "AES-GCM", false, ["encrypt", "decrypt"]);
+}
+
+async function encryptApiKey(value: string) {
+  if (!value) return "";
+  const key = await getOrCreateCryptoKey();
+  if (!key || typeof window === "undefined") return value;
+  const iv = window.crypto.getRandomValues(new Uint8Array(12));
+  const encoded = new TextEncoder().encode(value);
+  const cipher = await window.crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, encoded);
+  return `v1:${bytesToBase64(iv)}:${bytesToBase64(new Uint8Array(cipher))}`;
+}
+
+async function decryptApiKey(value: string) {
+  if (!value) return "";
+  if (!value.startsWith("v1:") || typeof window === "undefined") return value;
+  const key = await getOrCreateCryptoKey();
+  if (!key) return "";
+  const [, ivBase64, cipherBase64] = value.split(":");
+  if (!ivBase64 || !cipherBase64) return "";
+  const iv = base64ToBytes(ivBase64);
+  const cipher = base64ToBytes(cipherBase64);
+  try {
+    const plain = await window.crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, cipher);
+    return new TextDecoder().decode(plain);
+  } catch {
+    return "";
+  }
+}
+
 export function useAiKey(uid?: string | null) {
   const [aiKey, setAiKeyState] = useState<string>("");
   const [hydrated, setHydrated] = useState(false);
@@ -27,7 +81,9 @@ export function useAiKey(uid?: string | null) {
         
         if (!cancelled && docSnap.exists()) {
           const data = docSnap.data();
-          setAiKeyState(data?.geminiApiKey ?? "");
+          const rawKey = typeof data?.geminiApiKey === "string" ? data.geminiApiKey : "";
+          const decrypted = await decryptApiKey(rawKey);
+          setAiKeyState(decrypted);
         }
       } catch (error) {
         console.error("Error loading AI key from Firebase:", error);
@@ -60,7 +116,8 @@ export function useAiKey(uid?: string | null) {
         // Clear the key by setting it to empty string
         await setDoc(docRef, { geminiApiKey: "" }, { merge: true });
       } else {
-        await setDoc(docRef, { geminiApiKey: v }, { merge: true });
+        const encrypted = await encryptApiKey(v);
+        await setDoc(docRef, { geminiApiKey: encrypted }, { merge: true });
       }
     } catch (error) {
       console.error("Error saving AI key to Firebase:", error);
@@ -81,4 +138,3 @@ export function useAiKey(uid?: string | null) {
     clearAiKey,
   };
 }
-

--- a/src/lib/ai/webllm.ts
+++ b/src/lib/ai/webllm.ts
@@ -2,14 +2,14 @@
 
 import { CreateMLCEngine, MLCEngine } from "@mlc-ai/web-llm";
 
-// Qwen3-0.6B is a good balance between size and capability
-const MODEL_NAME = "Qwen3-0.6B-q4f16_1-MLC";
+// Qwen2.5-1.5B provides a stronger local baseline while remaining lightweight
+const MODEL_NAME = "Qwen2.5-1.5B-Instruct-q4f16_1-MLC";
 
 let engine: MLCEngine | null = null;
 let initPromise: Promise<MLCEngine> | null = null;
 
 /**
- * Initialize the WebLLM engine with Qwen3-0.6B model
+ * Initialize the WebLLM engine with Qwen2.5-1.5B model
  * This runs entirely in the browser using WebGPU
  */
 export async function initWebLLM(onProgress?: (progress: { text: string; progress: number }) => void): Promise<MLCEngine> {
@@ -56,20 +56,16 @@ export async function generateWithWebLLM(
 ): Promise<string> {
   const llm = await initWebLLM(onProgress);
 
-  const prompt = `You are a helpful AI assistant analyzing a personal timeline. Use the provided context to answer the user's question accurately and concisely.
-
-TIMELINE CONTEXT:
-${context}
-
-USER QUESTION: ${query}
-
-ANSWER:`;
-
   const response = await llm.chat.completions.create({
     messages: [
       {
+        role: "system",
+        content:
+          "You are a helpful AI assistant analyzing a personal timeline. Use only the provided context to answer accurately and concisely. If the answer is missing from context, say so.",
+      },
+      {
         role: "user",
-        content: prompt,
+        content: `TIMELINE CONTEXT:\n${context}\n\nUSER QUESTION: ${query}\n\nANSWER:`,
       },
     ],
     temperature: 0.7,


### PR DESCRIPTION
### Motivation
- Reduce wrong AI answers about the most-recent day by giving the model a better-ordered, richer context and increase the context budget. 
- Provide a stronger local LLM baseline so offline/local queries are more accurate. 
- Securely persist users' API keys and let users back out of key entry without interrupting local usage. 
- Make uploads feel celebratory and reposition the timeline AI chat below the main composer to give timeline chats full width and reduce layout crowding.

### Description
- Reworked timeline context in `src/lib/ai/context.ts` to sort chats by timestamp, raise `maxChars` to `32000`, expose `MOST RECENT DAY` and per-day counts, and include up to 30 recent entries. 
- Switched the local WebLLM model in `src/lib/ai/webllm.ts` to `Qwen2.5-1.5B-Instruct-q4f16_1-MLC`, added a clarifying system message, and kept the existing `generateWithWebLLM` API. 
- Added client-side encryption for stored API keys in `src/lib/ai/useAiKey.ts` using Web Crypto (`AES-GCM`) and write/read encrypted blobs to Firestore, with helper encode/decode utilities. 
- Updated `src/components/AiPanel.tsx` to duplicate the main input styling, increase panel height, make chats full-width, add a dismissible key-entry flow with a back button, and wire mode switches to respect the new key flow. 
- Moved the timeline AI panel placement and expanded the feed layout in `src/components/AppShell.tsx`, and added a `CelebrationBurst` visual plus logic to trigger a multi-spark burst when the send-flight animation completes. 
- Minor UI and behavior tweaks to make the timeline send/upload visuals feel like celebration and to reduce small layout jitter during interactions.

### Testing
- Started the dev server with `npm run dev` and the server reported readiness (Next.js started). 
- Ran a Playwright script that loaded `http://127.0.0.1:3000` and captured a full-page screenshot (`artifacts/.../timeline-ai-layout.png`), which completed successfully although Google Fonts failed to fetch in the environment and fallbacks were used. 
- No unit tests were added or run as part of this change; interactive verification was performed via the dev server and browser automation described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984258595e4832e8b2fc6a601bd443e)