### PR TITLE
Make main panels fit viewport and improve timeline image handling

### DIFF
--- a/src/components/AiPanel.tsx
+++ b/src/components/AiPanel.tsx
@@ -192,7 +192,7 @@ export function AiPanel({
       initial={{ opacity: 0, y: 30 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.8 }}
-      className="rounded-3xl border border-[var(--line)] bg-[var(--bg-elevated)]/70 backdrop-blur-2xl shadow-[0_20px_60px_rgba(0,0,0,0.5)] overflow-hidden"
+      className="rounded-3xl border border-[var(--line)] bg-[var(--bg-elevated)]/70 backdrop-blur-2xl shadow-[0_20px_60px_rgba(0,0,0,0.5)] overflow-hidden h-full flex flex-col"
       style={{
         boxShadow: "0 20px 60px rgba(0,0,0,0.5), 0 0 40px rgba(131,56,236,0.2) inset",
       }}
@@ -229,7 +229,7 @@ export function AiPanel({
         </div>
       </div>
 
-      <div className="px-6 py-6">
+      <div className="px-6 py-6 flex-1 min-h-0">
         {!hydrated || loading ? (
           <motion.div
             animate={{ opacity: [0.5, 1, 0.5] }}
@@ -371,7 +371,7 @@ export function AiPanel({
           <motion.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
-            className="flex flex-col h-[520px]"
+            className="flex flex-col h-full min-h-[360px]"
           >
             {/* Mode Selection and Settings */}
             <div className="flex items-center gap-3 px-6 pt-4 pb-3 border-b border-[var(--line)]">

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -448,55 +448,104 @@ export function AppShell() {
           onViewArchive={() => setShowArchive(true)}
         />
 
-        {/* Composer + stats with breathing effect - Hidden for guest mode */}
+        {/* Primary panels - Hidden for guest mode */}
         {!isGuest && (
           <motion.section
             initial={{ opacity: 0, y: 30 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.4, duration: 0.8 }}
-            className="flex flex-col items-center gap-6 mb-12"
+            className="flex flex-col gap-6 mb-10"
           >
-            <motion.div
-              animate={{
-                scale: [1, 1.01, 1],
-              }}
-              transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
-              className="w-full max-w-4xl"
-            >
-              <ChatComposer
-                disabled={sending}
-                onSendStart={(start) => {
-                  const startX = start.left + start.width / 2;
-                  const startY = start.top + start.height / 2;
-                  const target = timelineCardRef.current?.getBoundingClientRect();
-                  const endX = target ? target.right - 56 : startX;
-                  const endY = target ? target.top + target.height - 82 : startY - 120;
-                  const midX = (startX + endX) / 2 + 60;
-                  const midY = Math.min(startY, endY) - 130;
-                  setFlight({ id: Date.now(), startX, startY, midX, midY, endX, endY });
-                }}
-              onSend={async (text, imageFile) => {
-                if (!user?.uid) return;
-                setSending(true);
-                try {
-                  const id = await addChat(user.uid, text, imageFile);
-                  setHighlightChatId(id);
-                } finally {
-                  setSending(false);
-                }
-              }}
-              />
-            </motion.div>
-            {user && (
-              <motion.div
-                initial={{ opacity: 0, y: 20 }}
+            <div className="grid gap-6 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:min-h-[calc(100vh-320px)]">
+              <div className="flex flex-col gap-6 min-h-0">
+                <motion.div
+                  animate={{
+                    scale: [1, 1.01, 1],
+                  }}
+                  transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
+                  className="min-h-[220px] flex-1"
+                >
+                  <ChatComposer
+                    disabled={sending}
+                    onSendStart={(start) => {
+                      const startX = start.left + start.width / 2;
+                      const startY = start.top + start.height / 2;
+                      const target = timelineCardRef.current?.getBoundingClientRect();
+                      const endX = target ? target.right - 56 : startX;
+                      const endY = target ? target.top + target.height - 82 : startY - 120;
+                      const midX = (startX + endX) / 2 + 60;
+                      const midY = Math.min(startY, endY) - 130;
+                      setFlight({ id: Date.now(), startX, startY, midX, midY, endX, endY });
+                    }}
+                    onSend={async (text, imageFile) => {
+                      if (!user?.uid) return;
+                      setSending(true);
+                      try {
+                        const id = await addChat(user.uid, text, imageFile);
+                        setHighlightChatId(id);
+                      } finally {
+                        setSending(false);
+                      }
+                    }}
+                  />
+                </motion.div>
+                {user && (
+                  <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: 0.45, duration: 0.6 }}
+                    className="min-h-[260px] flex-1 min-h-0"
+                  >
+                    <AiPanel uid={user.uid} chats={chats} />
+                  </motion.div>
+                )}
+              </div>
+              <motion.section
+                ref={timelineCardRef}
+                initial={{ opacity: 0, y: 40 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.45, duration: 0.6 }}
-                className="w-full max-w-5xl"
+                transition={{ delay: 0.6, duration: 0.8 }}
+                className="relative rounded-3xl border border-[var(--line)] bg-[var(--bg-elevated)]/60 backdrop-blur-2xl shadow-[0_20px_60px_rgba(0,0,0,0.5)] overflow-hidden flex flex-col min-h-[260px]"
+                style={{
+                  boxShadow: "0 20px 60px rgba(0,0,0,0.5), 0 0 40px rgba(131,56,236,0.2) inset",
+                }}
               >
-                <AiPanel uid={user.uid} chats={chats} />
-              </motion.div>
-            )}
+                <motion.div
+                  className="absolute inset-0 bg-gradient-to-br from-[var(--glow-purple)]/10 via-transparent to-[var(--glow-cyan)]/10"
+                  animate={{
+                    opacity: [0.3, 0.5, 0.3],
+                  }}
+                  transition={{ duration: 4, repeat: Infinity }}
+                />
+                <div className="relative px-6 pt-6 pb-4 border-b border-[var(--line)]">
+                  <div className="flex items-center gap-2 text-[var(--text-primary)]">
+                    <motion.div
+                      animate={{ rotate: [0, 360] }}
+                      transition={{ duration: 10, repeat: Infinity, ease: "linear" }}
+                    >
+                      <Sparkles className="h-5 w-5 text-[var(--neon-cyan)]" />
+                    </motion.div>
+                    <div className="font-sans text-base font-semibold">Your timeline</div>
+                  </div>
+                  <div className="mt-2 text-sm text-[var(--text-secondary)]">
+                    {groupedByDay.size === 0
+                      ? "No marks yet. Start writing to see your story unfold."
+                      : `${groupedByDay.size} day${groupedByDay.size === 1 ? "" : "s"} recorded.`}
+                  </div>
+                </div>
+                <div className="flex-1 min-h-0">
+                  <TimelineBar
+                    groupedByDay={groupedByDay}
+                    newestChatId={newestChatId}
+                    highlightChatId={highlightChatId}
+                    onSelectChat={(id) => {
+                      const el = document.getElementById(`chat-${id}`);
+                      el?.scrollIntoView({ behavior: "smooth", block: "center" });
+                    }}
+                  />
+                </div>
+              </motion.section>
+            </div>
             <motion.div
               initial={{ opacity: 0, scale: 0.9 }}
               animate={{ opacity: 1, scale: 1 }}
@@ -507,54 +556,6 @@ export function AppShell() {
             </motion.div>
           </motion.section>
         )}
-      </div>
-
-      {/* Full-width timeline bar breaking out of container */}
-      <div className="mx-auto w-full relative z-10 mb-12">
-        {/* Timeline bar with 3D depth */}
-        <motion.section
-          ref={timelineCardRef}
-          initial={{ opacity: 0, y: 40 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.6, duration: 0.8 }}
-          className="relative rounded-3xl border border-[var(--line)] bg-[var(--bg-elevated)]/60 backdrop-blur-2xl shadow-[0_20px_60px_rgba(0,0,0,0.5)] overflow-hidden mx-6"
-          style={{
-            boxShadow: "0 20px 60px rgba(0,0,0,0.5), 0 0 40px rgba(131,56,236,0.2) inset",
-          }}
-        >
-          <motion.div
-            className="absolute inset-0 bg-gradient-to-br from-[var(--glow-purple)]/10 via-transparent to-[var(--glow-cyan)]/10"
-            animate={{
-              opacity: [0.3, 0.5, 0.3],
-            }}
-            transition={{ duration: 4, repeat: Infinity }}
-          />
-          <div className="relative px-6 pt-6 pb-4 border-b border-[var(--line)]">
-            <div className="flex items-center gap-2 text-[var(--text-primary)]">
-              <motion.div
-                animate={{ rotate: [0, 360] }}
-                transition={{ duration: 10, repeat: Infinity, ease: "linear" }}
-              >
-                <Sparkles className="h-5 w-5 text-[var(--neon-cyan)]" />
-              </motion.div>
-              <div className="font-sans text-base font-semibold">Your timeline</div>
-            </div>
-            <div className="mt-2 text-sm text-[var(--text-secondary)]">
-              {groupedByDay.size === 0
-                ? "No marks yet. Start writing to see your story unfold."
-                : `${groupedByDay.size} day${groupedByDay.size === 1 ? "" : "s"} recorded.`}
-            </div>
-          </div>
-          <TimelineBar
-            groupedByDay={groupedByDay}
-            newestChatId={newestChatId}
-            highlightChatId={highlightChatId}
-            onSelectChat={(id) => {
-              const el = document.getElementById(`chat-${id}`);
-              el?.scrollIntoView({ behavior: "smooth", block: "center" });
-            }}
-          />
-        </motion.section>
       </div>
 
       <div className="mx-auto w-full max-w-7xl relative z-10">

--- a/src/components/ChatFeed.tsx
+++ b/src/components/ChatFeed.tsx
@@ -289,7 +289,9 @@ function EntryCard({
             <img
               src={chat.imageUrl}
               alt="Entry image"
-              className="w-full h-auto object-contain"
+              loading="lazy"
+              decoding="async"
+              className="w-full h-auto max-h-[420px] object-contain bg-[var(--bg-deep)]/40"
             />
           </motion.div>
         )}

--- a/src/components/TimelineBar.tsx
+++ b/src/components/TimelineBar.tsx
@@ -165,7 +165,7 @@ export function TimelineBar({
   }, [days]);
 
   return (
-    <div className="px-6 py-6">
+    <div className="flex h-full flex-col px-6 py-6">
       <div className="flex items-center justify-between gap-4 mb-6">
         <motion.div
           initial={{ opacity: 0, x: -10 }}
@@ -198,6 +198,7 @@ export function TimelineBar({
         ref={viewport.ref}
         className={cn(
           "mt-4 rounded-2xl border border-[var(--line)] bg-[var(--bg-surface)]/40 backdrop-blur-xl",
+          "flex-1",
           "overflow-x-auto overscroll-x-contain",
           "shadow-[0_8px_32px_rgba(0,0,0,0.3)]",
           scrollable ? "pb-3" : "",
@@ -208,7 +209,7 @@ export function TimelineBar({
         }}
       >
         <div
-          className="relative h-[300px]"
+          className="relative min-h-[220px] h-full"
           style={{
             width: trackWidth,
             minWidth: "100%",

--- a/src/components/TimelineLog.tsx
+++ b/src/components/TimelineLog.tsx
@@ -208,7 +208,9 @@ function TimelineEntry({
               <img
                 src={chat.imageUrl}
                 alt="Entry image"
-                className="w-full h-auto max-h-96 object-contain"
+                loading="lazy"
+                decoding="async"
+                className="w-full h-auto max-h-[420px] object-contain bg-[var(--bg-deep)]/40"
               />
             </motion.div>
           )}


### PR DESCRIPTION
### Motivation
- Ensure all three primary panels (input composer, AI chat, rollercoaster timeline) are visible together on the main screen by dynamically sizing them so no outer scrolling is required.
- Improve image rendering inside timeline entries so added photos load lazily and display consistently within entries.

### Description
- Reworked the main panel area in `src/components/AppShell.tsx` into a responsive two-column grid so the composer + AI panel sit alongside the timeline bar and scale to available viewport height.
- Made the AI panel (`src/components/AiPanel.tsx`) and timeline container (`src/components/TimelineBar.tsx`) flex containers with `h-full`/`flex-1` and sensible `min-h` values so they expand/contract without causing page scroll.
- Moved the `TimelineBar` into the primary layout column and adjusted its internal container to use `min-h`/`h-full` so the rollercoaster visualization fits the allocated panel area.
- Updated timeline entry and chat feed image markup in `src/components/TimelineLog.tsx` and `src/components/ChatFeed.tsx` to use `loading="lazy"`, `decoding="async"`, a consistent `max-h` limit, and background styling for more polished presentation.
- Kept existing animations and interactivity (send flight, highlight behaviors, AI chat) but wire them to the new layout so they continue working when panels are resized.

### Testing
- Started the dev server with `npm run dev` and verified the app compiled and served locally (Next dev started and served pages). Success, though Google font downloads failed in the environment and fallbacks were used.
- Captured a full-page screenshot using a Playwright script to validate the three-panel layout (`artifacts/main-panels.png`) and confirmed the panels appear together without outer scrolling; the Playwright run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69842b0e7944832ebfc559cace367e73)